### PR TITLE
Fixed linking under g++-12.2.0 and libboost-1.74 or libboost-1.81

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CC := g++
 CPPFLAGS := -Iinclude -MMD -MP
 CFLAGS   := -Wall -DBOOST_NO_CXX11_SCOPED_ENUMS
 LDFLAGS  := -L/usr/include/boost -lboost_filesystem -lboost_system
-LDLIBS   := -lm 
+LDLIBS   := -lm -lboost_filesystem -lboost_system
 
 .PHONY: all install clean
 


### PR DESCRIPTION
Added lboost_system and lboost_filesystem library references to LDLIBS flag variable to fix issue where compiling under gcc-12.2.0 / g++12.2.0 with libboost-filesystem1.74-dev or libboost-filesystem1.81-dev would result in linking failing with error claiming that references to boost::filesystem::detail::status and boost::filesystem::detail::create_directory were undefined. 

(Issue discovered and fix tested/confirmed working under Debian 12.0 kernel 6.10-10 SMP PREEMPT_DYNAMIC)

Should (hopefully) still work just fine with previous compiler and libboost versions as the references to lboost_system and lboost_filesystem in the main LDFLAGS variable is unchanged and no warnings were generated when linking.