### PR TITLE
Changed reading bin files in chunks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -520,23 +520,14 @@ void dumpCombinedBins(const SystemVariables &vars, const CueHandler &cueIn,
 		
 		
 		//Get all the bytes from the current input and push them to output.
-		char cByte;
-		while(binFileIn.get(cByte)) {
-			//Put the read byte into the array
-			byteArray[arrBytes] = cByte;
-			++arrBytes;
-			
-			//If the array is full, dump it to the output file, and reset.
-			if(arrBytes == _def_ARR_SIZE) {
-				binFileOut.write(byteArray, _def_ARR_SIZE);
-				arrBytes = 0;
-			}
-			
-			//Keep track of how many bytes read so far, fileByte gets reset at
-			//next loop, totalBytes does not get reset
-			++totalBytes;
-			++fileBytes;
-		}
+		int bytesRead;
+		do {
+			binFileIn.read(byteArray, _def_ARR_SIZE);
+			bytesRead = binFileIn.gcount();
+			totalBytes += bytesRead;
+			fileBytes += bytesRead;
+			binFileOut.write(byteArray, bytesRead);
+		} while (bytesRead == _def_ARR_SIZE);
 		
 		//Close the current file for next loop
 		binFileIn.close();


### PR DESCRIPTION
Hello, I noticed that writing the combined bin files was a bit slow, and upon further inspection I managed to obtain a ~10x uplift by changing the routine for reading the input binary files to be chunked like the output.

```bash
$ ./psx-combine_old test/Brave\ Fencer\ Musashi\ \(USA\).cue -t -d 'test/psx-comBINe_old'
Created Directory: "test/psx-comBINe_old/"

Getting Input CUE Data... Done

Creating "test/psx-comBINe_old/Brave Fencer Musashi (USA).bin"
Dumping: Brave Fencer Musashi (USA) (Track 1).bin    347 MiB
Dumping: Brave Fencer Musashi (USA) (Track 2).bin     10 MiB
Dumping: Brave Fencer Musashi (USA) (Track 3).bin      6 MiB
Dumping: Brave Fencer Musashi (USA) (Track 4).bin     31 MiB

Finishing write to file ... Finished in 3.55 Seconds
Successfully dumped 416,021,760 Bytes to "test/psx-comBINe_old/Brave Fencer Musashi (USA).bin"
Wrote output .cue file to "test/psx-comBINe_old/Brave Fencer Musashi (USA).cue"

$ ./psx-combine test/Brave\ Fencer\ Musashi\ \(USA\).cue -t
Created Directory: "test/psx-comBINe"

Getting Input CUE Data... Done

Creating "test/psx-comBINe/Brave Fencer Musashi (USA).bin"
Dumping: Brave Fencer Musashi (USA) (Track 1).bin    347 MiB
Dumping: Brave Fencer Musashi (USA) (Track 2).bin     10 MiB
Dumping: Brave Fencer Musashi (USA) (Track 3).bin      6 MiB
Dumping: Brave Fencer Musashi (USA) (Track 4).bin     31 MiB

Finishing write to file ... Finished in 0.31 Seconds
Successfully dumped 416,021,760 Bytes to "test/psx-comBINe/Brave Fencer Musashi (USA).bin"
Wrote output .cue file to "test/psx-comBINe/Brave Fencer Musashi (USA).cue"

$ diff  "test/psx-comBINe/Brave Fencer Musashi (USA).bin" "test/psx-comBINe_old/Brave Fencer Musashi (USA).bin"


```